### PR TITLE
Add support for reStructuredText literal blocks

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ History
 
 * Require Black 22.1.0+.
 
+* Add ``--rst-literal-blocks`` option, to also format text in reStructuredText literal blocks, starting with ``::``.
+  Sphinx highlights these with the project’s default language, which defaults to Python.
+
 1.12.1 (2022-01-30)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ options:
 Following additional parameters can be used:
 
  - `-E` / `--skip-errors`
- - `--use-sphinx-default`
+ - `--rst-literal-blocks`
 
 `blacken-docs` will format code in the following block types:
 
@@ -60,14 +60,6 @@ Following additional parameters can be used:
             print("hello world")
 ```
 
-(rst using Sphinx default for blocks marked with `::`)
-``rst
-    hello::
-
-        def hello():
-            print("hello world")
-```
-
 This style is enabled with the `--use-sphinx-default` option.
 
 (rst `pycon`)
@@ -77,6 +69,19 @@ This style is enabled with the `--use-sphinx-default` option.
         >>> def hello():
         ...     print("hello world")
         ...
+```
+
+(rst literal blocks - activated with ``--rst-literal-blocks``)
+
+reStructuredText [literal blocks](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks) are marked with `::` and can be any monospaced text by default.
+However Sphinx interprets them as Python code [by default](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-literal-blocks).
+If your project uses Sphinx and such a configuration, add `--rst-literal-blocks` to also format such blocks.
+
+``rst
+    An example::
+
+        def hello():
+            print("hello world")
 ```
 
 (latex)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ options:
 Following additional parameters can be used:
 
  - `-E` / `--skip-errors`
+ - `--use-sphinx-default`
 
 `blacken-docs` will format code in the following block types:
 
@@ -58,6 +59,16 @@ Following additional parameters can be used:
         def hello():
             print("hello world")
 ```
+
+(rst using Sphinx default for blocks marked with `::`)
+``rst
+    hello::
+
+        def hello():
+            print("hello world")
+```
+
+This style is enabled with the `--use-sphinx-default` option.
 
 (rst `pycon`)
 ```rst

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -44,8 +44,7 @@ RST_RE = re.compile(
 )
 RST_LITERAL_BLOCKS_RE = re.compile(
     r'(?P<before>'
-    r'^(?P<indent> *)(?!\.\. )'
-    r'.*::\n'
+    r'^(?P<indent> *)(?!\.\. ).*::\n'
     r'((?P=indent) +:.*\n)*'
     r'\n*'
     r')'

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -130,6 +130,8 @@ def format_str(
         return f'{match["before"]}{code.rstrip()}{trailing_ws}'
 
     def _rst_literal_blocks_match(match: Match[str]) -> str:
+        if not match['code'].strip():
+            return match[0]
         min_indent = min(INDENT_RE.findall(match['code']))
         trailing_ws_match = TRAILING_NL_RE.search(match['code'])
         assert trailing_ws_match

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -44,7 +44,7 @@ RST_RE = re.compile(
 )
 RST_LITERAL_BLOCKS_RE = re.compile(
     r'(?P<before>'
-    r'^(?P<indent> *)(?!\.\. ).*::\n'
+    r'^(?! *\.\. )(?P<indent> *).*::\n'
     r'((?P=indent) +:.*\n)*'
     r'\n*'
     r')'

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from textwrap import dedent
+
 import black
 from black.const import DEFAULT_LINE_LENGTH
 
@@ -215,6 +217,23 @@ def test_format_src_rst_literal_blocks():
         '\n'
         'world\n'
     )
+
+
+def test_format_src_rst_literal_blocks_nested():
+    before = dedent(
+        '''
+        * hello
+
+          .. warning::
+
+            don't hello too much
+        ''',
+    )
+    after, errors = blacken_docs.format_str(
+        before, BLACK_MODE, rst_literal_blocks=True,
+    )
+    assert after == before
+    assert errors == []
 
 
 def test_format_src_rst_sphinx_doctest():

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -236,6 +236,23 @@ def test_format_src_rst_literal_blocks_nested():
     assert errors == []
 
 
+def test_format_src_rst_literal_blocks_empty():
+    before = dedent(
+        '''
+        Example::
+
+        .. warning::
+
+            There was no example.
+        ''',
+    )
+    after, errors = blacken_docs.format_str(
+        before, BLACK_MODE, rst_literal_blocks=True,
+    )
+    assert after == before
+    assert errors == []
+
+
 def test_format_src_rst_sphinx_doctest():
     before = (
         '.. testsetup:: group1\n'

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -197,7 +197,7 @@ def test_format_src_rst():
     )
 
 
-def test_format_src_rst_sphinx_default_language():
+def test_format_src_rst_literal_blocks():
     before = (
         'hello::\n'
         '\n'
@@ -205,7 +205,9 @@ def test_format_src_rst_sphinx_default_language():
         '\n'
         'world\n'
     )
-    after, _ = blacken_docs.format_str(before, BLACK_MODE, True)
+    after, _ = blacken_docs.format_str(
+        before, BLACK_MODE, rst_literal_blocks=True,
+    )
     assert after == (
         'hello::\n'
         '\n'

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -197,6 +197,24 @@ def test_format_src_rst():
     )
 
 
+def test_format_src_rst_sphinx_default_language():
+    before = (
+        'hello::\n'
+        '\n'
+        '    f(1,2,3)\n'
+        '\n'
+        'world\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        'hello::\n'
+        '\n'
+        '    f(1, 2, 3)\n'
+        '\n'
+        'world\n'
+    )
+
+
 def test_format_src_rst_sphinx_doctest():
     before = (
         '.. testsetup:: group1\n'

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -205,7 +205,7 @@ def test_format_src_rst_sphinx_default_language():
         '\n'
         'world\n'
     )
-    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    after, _ = blacken_docs.format_str(before, BLACK_MODE, True)
     assert after == (
         'hello::\n'
         '\n'


### PR DESCRIPTION
This is initial sketch to fix #195. It adds processing for Sphinx' default language blocks, marked with paragraphs ending `::`, which is common to all Sphinx projects using the defaults there (i.e. `sphinx-quickstart` generated). 

- [x] No doubt there's a wiggle or two in the regex, that we'll no doubt find running it against Django's docs. 
- [x] Would need a CLI flag. https://github.com/adamchainz/blacken-docs/pull/196/commits/a121cc09e0d0a26670ebef0b8ccdd1495307f7a6
- [x] ... (what else) ...

Opening early for input, and to let us experiment on the Django docs. 

