### PR TITLE
Adopt Mypy strict mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,5 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
+        additional_dependencies:
+        - black==22.12.0

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -10,6 +10,8 @@ from typing import NamedTuple
 from typing import Sequence
 
 import black
+from black.const import DEFAULT_LINE_LENGTH
+from black.mode import TargetVersion
 
 
 MD_RE = re.compile(
@@ -117,7 +119,7 @@ def format_str(
 
     def _pycon_match(match: Match[str]) -> str:
         code = ''
-        fragment = None
+        fragment: str | None = None
 
         def finish_fragment() -> None:
             nonlocal code
@@ -216,15 +218,15 @@ def format_file(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-l', '--line-length', type=int, default=black.DEFAULT_LINE_LENGTH,
+        '-l', '--line-length', type=int, default=DEFAULT_LINE_LENGTH,
     )
     parser.add_argument(
         '-t',
         '--target-version',
         action='append',
-        type=lambda v: black.TargetVersion[v.upper()],
+        type=lambda v: TargetVersion[v.upper()],
         default=[],
-        help=f'choices: {[v.name.lower() for v in black.TargetVersion]}',
+        help=f'choices: {[v.name.lower() for v in TargetVersion]}',
         dest='target_versions',
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+target-version = ['py37']
+
+[tool.mypy]
+mypy_path = "src/"
+namespace_packages = false
+show_error_codes = true
+strict = true
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+allow_untyped_defs = true
+
+[tool.pytest.ini_options]
+addopts = """\
+    --strict-config
+    --strict-markers
+    """

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-black
+black>=22.1.0
 coverage
 pytest
 pytest-randomly

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 [options]
 py_modules = blacken_docs
 install_requires =
-    black>=19.3b0
+    black>=22.1.0
 python_requires = >=3.7
 
 [options.entry_points]
@@ -40,18 +40,3 @@ source =
 
 [coverage:report]
 show_missing = True
-
-[mypy]
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-
-[mypy-testing.*]
-disallow_untyped_defs = false
-
-[mypy-tests.*]
-disallow_untyped_defs = false

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import black
+from black.const import DEFAULT_LINE_LENGTH
 
 import blacken_docs
 
 
-BLACK_MODE = black.FileMode(line_length=black.DEFAULT_LINE_LENGTH)
+BLACK_MODE = black.FileMode(line_length=DEFAULT_LINE_LENGTH)
 
 
 def test_format_src_trivial():


### PR DESCRIPTION
As a consequence, Black is required in the Mypy env. When adding it, we discover that some imports from within `black` are technically not re-exported, so move to their required location, and require non-beta black so they can always be found.