### PR TITLE
Issue 223 -- Remove outdated instruction from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,12 +48,6 @@ Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` f
             additional_dependencies:
             - black==22.12.0
 
-Then, reformat your entire project:
-
-.. code-block:: sh
-
-    pre-commit run blacken-docs --all-files
-
 Since Black is a moving target, it’s best to pin it in ``additional_dependencies``.
 Upgrade as appropriate.
 


### PR DESCRIPTION
## https://github.com/adamchainz/blacken-docs/issues/223

Hi @adamchainz I'm trying to have `blacken-docs` run for the entire Django docs, except `docs/releases`. Context: https://github.com/django/django/pull/16496#issuecomment-1433627279

I tried using `--all-files`, and noticed it's not in the package anymore.

This PR removes those lines from the `README.md`.

If you have a better way, i.e. to replace this rather than just remove it, please feel free to close/update this PR.

Thanks in advance!