### PR TITLE
Allow Markdown fence options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Allow Markdown fence options.
+
+  Thanks to initial work from Matthew Anderson in `PR #246 <https://github.com/adamchainz/blacken-docs/pull/246>`__.
+
 * Remove ``language_version`` from ``.pre-commit-hooks.yaml``.
   This change allows ``default_language_version`` in ``.pre-commit-config.yaml` to take precedence.
 

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -15,7 +15,7 @@ from black.mode import TargetVersion
 
 
 MD_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)```\s*python\n)"
+    r"(?P<before>^(?P<indent> *)```\s*python.*?\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)```\s*$)",
     re.DOTALL | re.MULTILINE,

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -15,13 +15,13 @@ from black.mode import TargetVersion
 
 
 MD_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)```\s*python( .*)?\n)"
+    r"(?P<before>^(?P<indent> *)```\s*python( .*?)?\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)```\s*$)",
     re.DOTALL | re.MULTILINE,
 )
 MD_PYCON_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)```\s*pycon\n)"
+    r"(?P<before>^(?P<indent> *)```\s*pycon( .*?)?\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)```.*$)",
     re.DOTALL | re.MULTILINE,

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -15,7 +15,7 @@ from black.mode import TargetVersion
 
 
 MD_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)```\s*python.*?\n)"
+    r"(?P<before>^(?P<indent> *)```\s*python( .*)?\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)```\s*$)",
     re.DOTALL | re.MULTILINE,

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -29,6 +29,12 @@ def test_format_src_markdown_leading_whitespace():
     assert after == ("```   python\n" "f(1, 2, 3)\n" "```\n")
 
 
+def test_format_src_markdown_options():
+    before = "```python title='example.py'\n" + "f(1,2,3)\n" + "```\n"
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == ("```python title='example.py'\n" + "f(1, 2, 3)\n" + "```\n")
+
+
 def test_format_src_markdown_trailing_whitespace():
     before = "```python\n" "f(1,2,3)\n" "```    \n"
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
@@ -40,6 +46,47 @@ def test_format_src_indented_markdown():
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == (
         "- do this pls:\n" "  ```python\n" "  f(1, 2, 3)\n" "  ```\n" "- also this\n"
+    )
+
+
+def test_format_src_markdown_pycon():
+    before = (
+        "hello\n"
+        "\n"
+        "```pycon\n"
+        "\n"
+        "    >>> f(1,2,3)\n"
+        "    output\n"
+        "```\n"
+        "world\n"
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        "hello\n" "\n" "```pycon\n" "\n" ">>> f(1, 2, 3)\n" "output\n" "```\n" "world\n"
+    )
+
+
+def test_format_src_markdown_pycon_options():
+    before = (
+        "hello\n"
+        "\n"
+        "```pycon title='Session 1'\n"
+        "\n"
+        "    >>> f(1,2,3)\n"
+        "    output\n"
+        "```\n"
+        "world\n"
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        "hello\n"
+        "\n"
+        "```pycon title='Session 1'\n"
+        "\n"
+        ">>> f(1, 2, 3)\n"
+        "output\n"
+        "```\n"
+        "world\n"
     )
 
 
@@ -743,21 +790,4 @@ def test_format_src_rst_pycon_comment_before_promopt():
         "\n"
         "    # Comment about next line\n"
         "    >>> pass\n"
-    )
-
-
-def test_format_src_markdown_pycon():
-    before = (
-        "hello\n"
-        "\n"
-        "```pycon\n"
-        "\n"
-        "    >>> f(1,2,3)\n"
-        "    output\n"
-        "```\n"
-        "world\n"
-    )
-    after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n" "\n" "```pycon\n" "\n" ">>> f(1, 2, 3)\n" "output\n" "```\n" "world\n"
     )


### PR DESCRIPTION
MkDocs Material uses a key-value syntax after the language in a markdown fence to allow [titling code-blocks](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#adding-a-title). `pymdownx` calls these ["options"](https://github.com/facelessuser/pymdown-extensions/blob/main/pymdownx/superfences.py#LL51C94-L51C94).

This relaxes the markdown regex to allow any text after ```` ```python```` on the first line, essentially ignoring these extra options.