### PR TITLE
Remove `language_version` from .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,4 @@
     description: Run `black` on python code blocks in documentation files
     entry: blacken-docs
     language: python
-    language_version: python3
     files: '\.(rst|md|markdown|py|tex)$'


### PR DESCRIPTION
This enables `default_language_version` stanzas
in consuming `.pre-commit-config.yaml` files to take precedence.

This change is the same as https://github.com/psf/black/pull/2430,
see that PR for full context on why this is beneficial.

This was previously PR'ed to this project as https://github.com/adamchainz/blacken-docs/pull/144.
It was closed at the time so my company has been keeping a fork of this project with the patch applied.
With the new maintainership, I wanted to ask whether this change would be accepted at this time.
Thanks in advance for taking a look, happy to answer any questions.