### PR TITLE
Use exit code 2 to indicate errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Changelog
 
   Thanks to Julianus Pfeuffer for the report in `Issue #217 <https://github.com/adamchainz/blacken-docs/issues/217>`__.
 
+* Use exit code 2 to indicate errors from Black, whilst exit code 1 remains for “files have been formatted”.
+
+  Thanks to Julianus Pfeuffer for the report in `Issue #218 <https://github.com/adamchainz/blacken-docs/issues/218>`__.
+
 * Remove ``language_version`` from ``.pre-commit-hooks.yaml``.
   This change allows ``default_language_version`` in ``.pre-commit-config.yaml` to take precedence.
 

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -243,7 +243,7 @@ def format_file(
         lineno = contents[: error.offset].count("\n") + 1
         print(f"{filename}:{lineno}: code block parse error {error.exc}")
     if errors and not skip_errors:
-        return 1
+        return 2
     if contents != new_contents:
         print(f"{filename}: Rewriting...")
         with open(filename, "w", encoding="UTF-8") as f:

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -439,7 +439,10 @@ def test_integration_ok(tmp_path, capsys):
     f.write_text(
         "```python\n" "f(1, 2, 3)\n" "```\n",
     )
-    assert not blacken_docs.main((str(f),))
+
+    result = blacken_docs.main((str(f),))
+
+    assert result == 0
     assert not capsys.readouterr()[1]
     assert f.read_text() == ("```python\n" "f(1, 2, 3)\n" "```\n")
 
@@ -449,7 +452,10 @@ def test_integration_modifies(tmp_path, capsys):
     f.write_text(
         "```python\n" "f(1,2,3)\n" "```\n",
     )
-    assert blacken_docs.main((str(f),))
+
+    result = blacken_docs.main((str(f),))
+
+    assert result == 1
     out, _ = capsys.readouterr()
     assert out == f"{f}: Rewriting...\n"
     assert f.read_text() == ("```python\n" "f(1, 2, 3)\n" "```\n")
@@ -462,7 +468,10 @@ def test_integration_line_length(tmp_path):
         "foo(very_very_very_very_very_very_very, long_long_long_long_long)\n"
         "```\n",
     )
-    assert not blacken_docs.main((str(f), "--line-length=80"))
+
+    result = blacken_docs.main((str(f), "--line-length=80"))
+
+    assert result == 0
     assert blacken_docs.main((str(f), "--line-length=50"))
     assert f.read_text() == (
         "```python\n"
@@ -486,8 +495,13 @@ def test_integration_py36(tmp_path):
         "    pass\n"
         "```\n",
     )
-    assert not blacken_docs.main((str(f),))
-    assert blacken_docs.main((str(f), "--target-version=py36"))
+
+    result = blacken_docs.main((str(f),))
+    assert result == 0
+
+    result2 = blacken_docs.main((str(f), "--target-version=py36"))
+
+    assert result2 == 1
     assert f.read_text() == (
         "```python\n"
         "def very_very_long_function_name(\n"
@@ -512,8 +526,13 @@ def test_integration_filename_last(tmp_path):
         "    pass\n"
         "```\n",
     )
-    assert not blacken_docs.main((str(f),))
-    assert blacken_docs.main(("--target-version", "py36", str(f)))
+
+    result = blacken_docs.main((str(f),))
+    assert result == 0
+
+    result2 = blacken_docs.main(("--target-version", "py36", str(f)))
+
+    assert result2 == 1
     assert f.read_text() == (
         "```python\n"
         "def very_very_long_function_name(\n"
@@ -538,10 +557,14 @@ def test_integration_multiple_target_version(tmp_path):
         "    pass\n"
         "```\n",
     )
-    assert not blacken_docs.main((str(f),))
-    assert not blacken_docs.main(
+
+    result = blacken_docs.main((str(f),))
+    assert result == 0
+
+    result2 = blacken_docs.main(
         ("--target-version", "py35", "--target-version", "py36", str(f)),
     )
+    assert result2 == 0
 
 
 def test_integration_skip_string_normalization(tmp_path):
@@ -549,7 +572,10 @@ def test_integration_skip_string_normalization(tmp_path):
     f.write_text(
         "```python\n" "f('hi')\n" "```\n",
     )
-    assert not blacken_docs.main((str(f), "--skip-string-normalization"))
+
+    result = blacken_docs.main((str(f), "--skip-string-normalization"))
+
+    assert result == 0
     assert f.read_text() == ("```python\n" "f('hi')\n" "```\n")
 
 
@@ -558,7 +584,10 @@ def test_integration_syntax_error(tmp_path, capsys):
     f.write_text(
         "```python\n" "f(\n" "```\n",
     )
-    assert blacken_docs.main((str(f),))
+
+    result = blacken_docs.main((str(f),))
+
+    assert result == 2
     out, _ = capsys.readouterr()
     assert out.startswith(f"{f}:1: code block parse error")
     assert f.read_text() == ("```python\n" "f(\n" "```\n")
@@ -569,7 +598,10 @@ def test_integration_ignored_syntax_error(tmp_path, capsys):
     f.write_text(
         "```python\n" "f( )\n" "```\n" "\n" "```python\n" "f(\n" "```\n",
     )
-    assert blacken_docs.main((str(f), "--skip-errors"))
+
+    result = blacken_docs.main((str(f), "--skip-errors"))
+
+    assert result == 1
     out, _ = capsys.readouterr()
     assert f.read_text() == (
         "```python\n" "f()\n" "```\n" "\n" "```python\n" "f(\n" "```\n"


### PR DESCRIPTION
Fixes #218.

Using exit code 2 for input errors inspired by `grep`.