### PR TITLE
feat: brace fences

### DIFF
--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -21,6 +21,12 @@ MD_RE = re.compile(
     r"(?P<after>^(?P=indent)```\s*$)",
     re.DOTALL | re.MULTILINE,
 )
+MD_BRACE_RE = re.compile(
+    r"(?P<before>^(?P<indent> *)```\s*\{\s*\.python( [^\}\n]*?)?\}\s*?\n)"
+    r"(?P<code>.*?)"
+    r"(?P<after>^(?P=indent)```\s*$)",
+    re.DOTALL | re.MULTILINE,
+)
 MD_PYCON_RE = re.compile(
     r"(?P<before>^(?P<indent> *)```\s*pycon( .*?)?\n)"
     r"(?P<code>.*?)"
@@ -212,6 +218,7 @@ def format_str(
         return f'{match["before"]}{code}{match["after"]}'
 
     src = MD_RE.sub(_md_match, src)
+    src = MD_BRACE_RE.sub(_md_match, src)
     src = MD_PYCON_RE.sub(_md_pycon_match, src)
     src = RST_RE.sub(_rst_match, src)
     src = RST_PYCON_RE.sub(_rst_pycon_match, src)

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -88,6 +88,23 @@ def test_format_src_markdown_options():
         """
     )
 
+def test_format_src_markdown_braces():
+    before = dedent(
+        """\
+        ```{.python title='example.py'}
+        f(1,2,3)
+        ```
+        """
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == dedent(
+        """\
+        ```{.python title='example.py'}
+        f(1, 2, 3)
+        ```
+        """
+    )
+
 
 def test_format_src_markdown_trailing_whitespace():
     before = dedent(


### PR DESCRIPTION
This supports the [brace format](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#injecting-classes-ids-and-attributes) in superfences. The blocks are processed the same as normal markdown code blocks. The only difference is the `before` line. 