### PR TITLE
Ignore language specifiers after newlines in Markdown code blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Changelog
 
   Thanks to Peter Cock in `PR #313 <https://github.com/adamchainz/blacken-docs/pull/313>`__.
 
+* Ignore language specifiers after newlines in Markdown code blocks.
+
+  Thanks to Harutaka Kawamura in `PR #283 <https://github.com/adamchainz/blacken-docs/pull/283>`__.
+
 1.16.0 (2023-08-16)
 -------------------
 

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -16,13 +16,15 @@ from black.mode import TargetVersion
 PYGMENTS_PY_LANGS = frozenset(("python", "py", "sage", "python3", "py3", "numpy"))
 PYGMENTS_PY_LANGS_RE_FRAGMENT = f"({'|'.join(PYGMENTS_PY_LANGS)})"
 MD_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)```\s*" + PYGMENTS_PY_LANGS_RE_FRAGMENT + r"( .*?)?\n)"
+    r"(?P<before>^(?P<indent> *)```[^\S\r\n]*"
+    + PYGMENTS_PY_LANGS_RE_FRAGMENT
+    + r"( .*?)?\n)"
     r"(?P<code>.*?)"
-    r"(?P<after>^(?P=indent)```\s*$)",
+    r"(?P<after>^(?P=indent)```[^\S\r\n]*$)",
     re.DOTALL | re.MULTILINE,
 )
 MD_PYCON_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)```\s*pycon( .*?)?\n)"
+    r"(?P<before>^(?P<indent> *)```[^\S\r\n]*pycon( .*?)?\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)```.*$)",
     re.DOTALL | re.MULTILINE,

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -53,6 +53,20 @@ def test_format_src_markdown_leading_whitespace():
     )
 
 
+def test_format_src_markdown_python_after_newline():
+    before = dedent(
+        """\
+        ```
+        python --version
+        echo "python"
+        ```
+        """
+    )
+    after, errors = blacken_docs.format_str(before, BLACK_MODE)
+    assert errors == []
+    assert after == before
+
+
 def test_format_src_markdown_short_name():
     before = dedent(
         """\
@@ -142,6 +156,20 @@ def test_format_src_markdown_pycon():
     assert after == (
         "hello\n" "\n" "```pycon\n" "\n" ">>> f(1, 2, 3)\n" "output\n" "```\n" "world\n"
     )
+
+
+def test_format_src_markdown_pycon_after_newline():
+    before = dedent(
+        """\
+        ```
+        pycon is great
+        >>> yes it is
+        ```
+        """
+    )
+    after, errors = blacken_docs.format_str(before, BLACK_MODE)
+    assert errors == []
+    assert after == before
 
 
 def test_format_src_markdown_pycon_options():


### PR DESCRIPTION
The current implementation thinks the following markdown codeblock is python code, but it's not:

````
```
python a.py
```
````

This PR fixes this issue.