### PR TITLE
Using `types_or` over `files` in `pre-commit` hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
     description: Run `black` on python code blocks in documentation files
     entry: blacken-docs
     language: python
-    files: '\.(rst|md|markdown|py|tex)$'
+    types_or: [rst, markdown, tex, python, pyi, jupyter]


### PR DESCRIPTION
- Fixes https://github.com/adamchainz/blacken-docs/issues/297
- Adds Jupyter Notebooks to the list of targets