### PR TITLE
Allow options for LaTeX minted blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 
   Thanks to Joaquim Esteves in `PR #278 <https://github.com/adamchainz/blacken-docs/pull/278>`__.
 
+* Allow options in LaTeX minted blocks.
+
+  Thanks to Peter Cock in `PR #313 <https://github.com/adamchainz/blacken-docs/pull/313>`__.
+
 1.16.0 (2023-08-16)
 -------------------
 

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -66,13 +66,13 @@ PYCON_CONTINUATION_RE = re.compile(
     rf"^{re.escape(PYCON_CONTINUATION_PREFIX)}( |$)",
 )
 LATEX_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)\\begin{minted}{python}\n)"
+    r"(?P<before>^(?P<indent> *)\\begin{minted}(\[.*?\])?{python}\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)\\end{minted}\s*$)",
     re.DOTALL | re.MULTILINE,
 )
 LATEX_PYCON_RE = re.compile(
-    r"(?P<before>^(?P<indent> *)\\begin{minted}{pycon}\n)"
+    r"(?P<before>^(?P<indent> *)\\begin{minted}(\[.*?\])?{pycon}\n)"
     r"(?P<code>.*?)"
     r"(?P<after>^(?P=indent)\\end{minted}\s*$)",
     re.DOTALL | re.MULTILINE,

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -178,6 +178,30 @@ def test_format_src_latex_minted():
     )
 
 
+def test_format_src_latex_minted_opt():
+    before = (
+        "maths!\n"
+        "\\begin{minted}[mathescape]{python}\n"
+        "# Returns $\\sum_{i=1}^{n}i$\n"
+        "def sum_from_one_to(n):\n"
+        "  r = range(1, n+1)\n"
+        "  return sum(r)\n"
+        "\\end{minted}\n"
+        "done"
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        "maths!\n"
+        "\\begin{minted}[mathescape]{python}\n"
+        "# Returns $\\sum_{i=1}^{n}i$\n"
+        "def sum_from_one_to(n):\n"
+        "    r = range(1, n + 1)\n"
+        "    return sum(r)\n"
+        "\\end{minted}\n"
+        "done"
+    )
+
+
 def test_format_src_latex_minted_indented():
     # Personaly I would have minted python code all flush left,
     # with only the Python code's own four space indentation:
@@ -203,7 +227,7 @@ def test_format_src_latex_minted_indented():
 def test_format_src_latex_minted_pycon():
     before = (
         "Preceeding text\n"
-        "\\begin{minted}{pycon}\n"
+        "\\begin{minted}[gobble=2,showspaces]{pycon}\n"
         ">>> print( 'Hello World' )\n"
         "Hello World\n"
         "\\end{minted}\n"
@@ -212,7 +236,7 @@ def test_format_src_latex_minted_pycon():
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == (
         "Preceeding text\n"
-        "\\begin{minted}{pycon}\n"
+        "\\begin{minted}[gobble=2,showspaces]{pycon}\n"
         '>>> print("Hello World")\n'
         "Hello World\n"
         "\\end{minted}\n"


### PR DESCRIPTION
I've not used them much, but LaTeX minted blocks can have optional arguments. My original regex did not consider this. Test and proposed fix attached.