### PR TITLE
Use isort to sort imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,16 +43,11 @@ repos:
     additional_dependencies:
     - black==23.1.0
     files: '\.rst$'
-- repo: https://github.com/asottile/reorder-python-imports
-  rev: v3.12.0
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
   hooks:
-  - id: reorder-python-imports
-    args:
-    - --py38-plus
-    - --application-directories
-    - .:example:src
-    - --add-import
-    - 'from __future__ import annotations'
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/PyCQA/flake8
   rev: 7.0.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,13 @@ blacken-docs = "blacken_docs:main"
 [tool.black]
 target-version = ['py38']
 
+[tool.isort]
+add_imports = [
+    "from __future__ import annotations"
+]
+force_single_line = true
+profile = "black"
+
 [tool.pytest.ini_options]
 addopts = """\
     --strict-config

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -12,7 +12,6 @@ import black
 from black.const import DEFAULT_LINE_LENGTH
 from black.mode import TargetVersion
 
-
 PYGMENTS_PY_LANGS = frozenset(("python", "py", "sage", "python3", "py3", "numpy"))
 PYGMENTS_PY_LANGS_RE_FRAGMENT = f"({'|'.join(PYGMENTS_PY_LANGS)})"
 MD_RE = re.compile(

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -8,7 +8,6 @@ from black.const import DEFAULT_LINE_LENGTH
 import blacken_docs
 from blacken_docs import __main__  # noqa: F401
 
-
 BLACK_MODE = black.FileMode(line_length=DEFAULT_LINE_LENGTH)
 
 


### PR DESCRIPTION
Switching because reorder-python-imports is incompatible with Black 24: https://github.com/asottile/reorder-python-imports/issues/366  / https://github.com/psf/black/issues/4175 .
