### PR TITLE
Fix workflow visibility badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 blacken-docs
 ============
 
-.. image:: https://img.shields.io/github/actions/workflow/status/adamchainz/blacken-docs/main.yml?branch=main&style=for-the-badge
+.. image:: https://img.shields.io/github/actions/workflow/status/adamchainz/blacken-docs/main.yml.svg?branch=main&style=for-the-badge
    :target: https://github.com/adamchainz/blacken-docs/actions?workflow=CI
 
 .. image:: https://img.shields.io/badge/Coverage-100%25-success?style=for-the-badge


### PR DESCRIPTION
In README file in .rst format, badges from Shields.io on GitHub workflows require a ".svg" in the path after the ".yml"