### PR TITLE
Fix Markdown pycon formatting remainder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Fix Markdown ``pycon`` formatting to allow formatting the rest of the file.
+
 1.17.0 (2024-06-29)
 -------------------
 

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -25,7 +25,7 @@ MD_RE = re.compile(
 MD_PYCON_RE = re.compile(
     r"(?P<before>^(?P<indent> *)```[^\S\r\n]*pycon( .*?)?\n)"
     r"(?P<code>.*?)"
-    r"(?P<after>^(?P=indent)```.*$)",
+    r"(?P<after>^(?P=indent)```[^\S\r\n]*$)",
     re.DOTALL | re.MULTILINE,
 )
 BLOCK_TYPES = "(code|code-block|sourcecode|ipython)"

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -195,6 +195,32 @@ def test_format_src_markdown_pycon_options():
     )
 
 
+def test_format_src_markdown_pycon_twice():
+    before = (
+        "```pycon\n"
+        ">>> f(1,2,3)\n"
+        "output\n"
+        "```\n"
+        "example 2\n"
+        "```pycon\n"
+        ">>> f(1,2,3)\n"
+        "output\n"
+        "```\n"
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        "```pycon\n"
+        ">>> f(1, 2, 3)\n"
+        "output\n"
+        "```\n"
+        "example 2\n"
+        "```pycon\n"
+        ">>> f(1, 2, 3)\n"
+        "output\n"
+        "```\n"
+    )
+
+
 def test_format_src_latex_minted():
     before = (
         "hello\n" "\\begin{minted}{python}\n" "f(1,2,3)\n" "\\end{minted}\n" "world!"


### PR DESCRIPTION
Applying the same edit from #283.