### PR TITLE
reStructuredText: gracefully ignore empty code blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* reStructuredText: Gracefully ignore empty code blocks.
+
+  Thanks to Stephen Rosen in `PR #368 <https://github.com/adamchainz/blacken-docs/issues/368>`__.
+
 * Drop Python 3.8 support.
 
 * Support Python 3.13.

--- a/src/blacken_docs/__init__.py
+++ b/src/blacken_docs/__init__.py
@@ -159,6 +159,8 @@ def format_str(
         lang = match["lang"]
         if lang is not None and lang not in PYGMENTS_PY_LANGS:
             return match[0]
+        if not match["code"].strip():
+            return match[0]
         min_indent = min(INDENT_RE.findall(match["code"]))
         trailing_ws_match = TRAILING_NL_RE.search(match["code"])
         assert trailing_ws_match
@@ -240,6 +242,8 @@ def format_str(
         if _within_off_range(match.span()):
             return match[0]
         code = _pycon_match(match)
+        if not code.strip():
+            return match[0]
         min_indent = min(INDENT_RE.findall(match["code"]))
         code = textwrap.indent(code, min_indent)
         return f'{match["before"]}{code}'

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -1323,3 +1323,15 @@ def test_format_src_rst_pycon_comments():
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
+
+
+def test_format_empty_python_code_block():
+    before = "some text\n\n.. code-block:: python\n\n\nsome other text\n"
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == before
+
+
+def test_format_empty_pycon_code_block():
+    before = "some text\n\n.. code-block:: pycon\n\n\nsome other text\n"
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == before

--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -534,6 +534,12 @@ def test_format_src_rst():
     )
 
 
+def test_format_src_rst_empty():
+    before = "some text\n\n.. code-block:: python\n\n\nsome other text\n"
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == before
+
+
 def test_format_src_rst_literal_blocks():
     before = dedent(
         """\
@@ -558,6 +564,21 @@ def test_format_src_rst_literal_blocks():
         world
         """
     )
+
+
+def test_format_src_rst_literal_block_empty():
+    before = dedent(
+        """\
+        hello::
+        world
+        """
+    )
+    after, _ = blacken_docs.format_str(
+        before,
+        BLACK_MODE,
+        rst_literal_blocks=True,
+    )
+    assert after == before
 
 
 def test_format_src_rst_literal_blocks_nested():
@@ -1325,13 +1346,7 @@ def test_format_src_rst_pycon_comments():
     assert after == before
 
 
-def test_format_empty_python_code_block():
-    before = "some text\n\n.. code-block:: python\n\n\nsome other text\n"
-    after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == before
-
-
-def test_format_empty_pycon_code_block():
+def test_format_src_rst_pycon_empty():
     before = "some text\n\n.. code-block:: pycon\n\n\nsome other text\n"
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before


### PR DESCRIPTION
Fixes #368

---

I only added cases for `python` and `pycon` blocks, but I also see that there are some kinds of nested matching.
I wasn't sure if there are other cases I should consider, so I constrained the changes as a good starting point.
I'm happy to cover more cases if there are more I should check.
