### PR TITLE
Convert all test examples to use dedent()

### DIFF
--- a/tests/test_blacken_docs.py
+++ b/tests/test_blacken_docs.py
@@ -141,19 +141,30 @@ def test_format_src_indented_markdown():
 
 
 def test_format_src_markdown_pycon():
-    before = (
-        "hello\n"
-        "\n"
-        "```pycon\n"
-        "\n"
-        "    >>> f(1,2,3)\n"
-        "    output\n"
-        "```\n"
-        "world\n"
+    before = dedent(
+        """\
+        hello
+
+        ```pycon
+
+            >>> f(1,2,3)
+            output
+        ```
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n" "\n" "```pycon\n" "\n" ">>> f(1, 2, 3)\n" "output\n" "```\n" "world\n"
+    assert after == dedent(
+        """\
+        hello
+
+        ```pycon
+
+        >>> f(1, 2, 3)
+        output
+        ```
+        world
+        """
     )
 
 
@@ -172,152 +183,180 @@ def test_format_src_markdown_pycon_after_newline():
 
 
 def test_format_src_markdown_pycon_options():
-    before = (
-        "hello\n"
-        "\n"
-        "```pycon title='Session 1'\n"
-        "\n"
-        "    >>> f(1,2,3)\n"
-        "    output\n"
-        "```\n"
-        "world\n"
+    before = dedent(
+        """\
+        hello
+
+        ```pycon title='Session 1'
+
+            >>> f(1,2,3)
+            output
+        ```
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n"
-        "\n"
-        "```pycon title='Session 1'\n"
-        "\n"
-        ">>> f(1, 2, 3)\n"
-        "output\n"
-        "```\n"
-        "world\n"
+    assert after == dedent(
+        """\
+        hello
+
+        ```pycon title='Session 1'
+
+        >>> f(1, 2, 3)
+        output
+        ```
+        world
+        """
     )
 
 
 def test_format_src_markdown_pycon_twice():
-    before = (
-        "```pycon\n"
-        ">>> f(1,2,3)\n"
-        "output\n"
-        "```\n"
-        "example 2\n"
-        "```pycon\n"
-        ">>> f(1,2,3)\n"
-        "output\n"
-        "```\n"
+    before = dedent(
+        """\
+        ```pycon
+        >>> f(1,2,3)
+        output
+        ```
+        example 2
+        ```pycon
+        >>> f(1,2,3)
+        output
+        ```
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "```pycon\n"
-        ">>> f(1, 2, 3)\n"
-        "output\n"
-        "```\n"
-        "example 2\n"
-        "```pycon\n"
-        ">>> f(1, 2, 3)\n"
-        "output\n"
-        "```\n"
+    assert after == dedent(
+        """\
+        ```pycon
+        >>> f(1, 2, 3)
+        output
+        ```
+        example 2
+        ```pycon
+        >>> f(1, 2, 3)
+        output
+        ```
+        """
     )
 
 
 def test_format_src_markdown_comments_disable():
-    before = (
-        "<!-- blacken-docs:off -->\n"
-        "```python\n"
-        "'single quotes rock'\n"
-        "```\n"
-        "<!-- blacken-docs:on -->\n"
+    before = dedent(
+        """\
+        <!-- blacken-docs:off -->
+        ```python
+        'single quotes rock'
+        ```
+        <!-- blacken-docs:on -->
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_markdown_comments_disabled_enabled():
-    before = (
-        "<!-- blacken-docs:off -->\n"
-        "```python\n"
-        "'single quotes rock'\n"
-        "```\n"
-        "<!-- blacken-docs:on -->\n"
-        "```python\n"
-        "'double quotes rock'\n"
-        "```\n"
+    before = dedent(
+        """\
+        <!-- blacken-docs:off -->
+        ```python
+        'single quotes rock'
+        ```
+        <!-- blacken-docs:on -->
+        ```python
+        'double quotes rock'
+        ```
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "<!-- blacken-docs:off -->\n"
-        "```python\n"
-        "'single quotes rock'\n"
-        "```\n"
-        "<!-- blacken-docs:on -->\n"
-        "```python\n"
-        '"double quotes rock"\n'
-        "```\n"
+    assert after == dedent(
+        """\
+        <!-- blacken-docs:off -->
+        ```python
+        'single quotes rock'
+        ```
+        <!-- blacken-docs:on -->
+        ```python
+        "double quotes rock"
+        ```
+        """
     )
 
 
 def test_format_src_markdown_comments_before():
-    before = (
-        "<!-- blacken-docs:off -->\n"
-        "<!-- blacken-docs:on -->\n"
-        "```python\n"
-        "'double quotes rock'\n"
-        "```\n"
+    before = dedent(
+        """\
+        <!-- blacken-docs:off -->
+        <!-- blacken-docs:on -->
+        ```python
+        'double quotes rock'
+        ```
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "<!-- blacken-docs:off -->\n"
-        "<!-- blacken-docs:on -->\n"
-        "```python\n"
-        '"double quotes rock"\n'
-        "```\n"
+    assert after == dedent(
+        """\
+        <!-- blacken-docs:off -->
+        <!-- blacken-docs:on -->
+        ```python
+        "double quotes rock"
+        ```
+        """
     )
 
 
 def test_format_src_markdown_comments_after():
-    before = (
-        "```python\n"
-        "'double quotes rock'\n"
-        "```\n"
-        "<!-- blacken-docs:off -->\n"
-        "<!-- blacken-docs:on -->\n"
+    before = dedent(
+        """\
+        ```python
+        'double quotes rock'
+        ```
+        <!-- blacken-docs:off -->
+        <!-- blacken-docs:on -->
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "```python\n"
-        '"double quotes rock"\n'
-        "```\n"
-        "<!-- blacken-docs:off -->\n"
-        "<!-- blacken-docs:on -->\n"
+    assert after == dedent(
+        """\
+        ```python
+        "double quotes rock"
+        ```
+        <!-- blacken-docs:off -->
+        <!-- blacken-docs:on -->
+        """
     )
 
 
 def test_format_src_markdown_comments_only_on():
     # fmt: off
-    before = (
-        "<!-- blacken-docs:on -->\n"
-        "```python\n"
-        "'double quotes rock'\n"
-        "```\n"
+    before = dedent(
+        """\
+        <!-- blacken-docs:on -->
+        ```python
+        'double quotes rock'
+        ```
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "<!-- blacken-docs:on -->\n"
-        "```python\n"
-        '"double quotes rock"\n'
-        "```\n"
+    assert after == dedent(
+        """\
+        <!-- blacken-docs:on -->
+        ```python
+        "double quotes rock"
+        ```
+        """
     )
     # fmt: on
 
 
 def test_format_src_markdown_comments_only_off():
     # fmt: off
-    before = (
-        "<!-- blacken-docs:off -->\n"
-        "```python\n"
-        "'single quotes rock'\n"
-        "```\n"
+    before = dedent(
+        """\
+        <!-- blacken-docs:off -->
+        ```python
+        'single quotes rock'
+        ```
+        """
     )
     # fmt: on
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
@@ -325,78 +364,100 @@ def test_format_src_markdown_comments_only_off():
 
 
 def test_format_src_markdown_comments_multiple():
-    before = (
-        "<!-- blacken-docs:on -->\n"  # ignored
-        "<!-- blacken-docs:off -->\n"
-        "<!-- blacken-docs:on -->\n"
-        "<!-- blacken-docs:on -->\n"  # ignored
-        "<!-- blacken-docs:off -->\n"
-        "<!-- blacken-docs:off -->\n"  # ignored
-        "```python\n"
-        "'single quotes rock'\n"
-        "```\n"  # no on comment, off until the end
+    before = dedent(
+        """\
+        <!-- blacken-docs:on -->
+        <!-- blacken-docs:off -->
+        <!-- blacken-docs:on -->
+        <!-- blacken-docs:on -->
+        <!-- blacken-docs:off -->
+        <!-- blacken-docs:off -->
+        ```python
+        'single quotes rock'
+        ```
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_on_off_comments_in_code_blocks():
-    before = (
-        "````md\n"
-        "<!-- blacken-docs:off -->\n"
-        "```python\n"
-        "f(1,2,3)\n"
-        "```\n"
-        "<!-- blacken-docs:on -->\n"
-        "````\n"
+    before = dedent(
+        """\
+        ````md
+        <!-- blacken-docs:off -->
+        ```python
+        f(1,2,3)
+        ```
+        <!-- blacken-docs:on -->
+        ````
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_markdown_comments_disable_pycon():
-    before = (
-        "<!-- blacken-docs:off -->\n"
-        "```pycon\n"
-        ">>> 'single quotes rock'\n"
-        "```\n"
-        "<!-- blacken-docs:on -->\n"
+    before = dedent(
+        """\
+        <!-- blacken-docs:off -->
+        ```pycon
+        >>> 'single quotes rock'
+        ```
+        <!-- blacken-docs:on -->
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_latex_minted():
-    before = (
-        "hello\n" "\\begin{minted}{python}\n" "f(1,2,3)\n" "\\end{minted}\n" "world!"
+    before = dedent(
+        """\
+        hello
+        \\begin{minted}{python}
+        f(1,2,3)
+        \\end{minted}
+        world!
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n" "\\begin{minted}{python}\n" "f(1, 2, 3)\n" "\\end{minted}\n" "world!"
+    assert after == dedent(
+        """\
+        hello
+        \\begin{minted}{python}
+        f(1, 2, 3)
+        \\end{minted}
+        world!
+        """
     )
 
 
 def test_format_src_latex_minted_opt():
-    before = (
-        "maths!\n"
-        "\\begin{minted}[mathescape]{python}\n"
-        "# Returns $\\sum_{i=1}^{n}i$\n"
-        "def sum_from_one_to(n):\n"
-        "  r = range(1, n+1)\n"
-        "  return sum(r)\n"
-        "\\end{minted}\n"
-        "done"
+    before = dedent(
+        """\
+        maths!
+        \\begin{minted}[mathescape]{python}
+        # Returns $\\sum_{i=1}^{n}i$
+        def sum_from_one_to(n):
+          r = range(1, n+1)
+          return sum(r)
+        \\end{minted}
+        done
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "maths!\n"
-        "\\begin{minted}[mathescape]{python}\n"
-        "# Returns $\\sum_{i=1}^{n}i$\n"
-        "def sum_from_one_to(n):\n"
-        "    r = range(1, n + 1)\n"
-        "    return sum(r)\n"
-        "\\end{minted}\n"
-        "done"
+    assert after == dedent(
+        """\
+        maths!
+        \\begin{minted}[mathescape]{python}
+        # Returns $\\sum_{i=1}^{n}i$
+        def sum_from_one_to(n):
+            r = range(1, n + 1)
+            return sum(r)
+        \\end{minted}
+        done
+        """
     )
 
 
@@ -427,66 +488,78 @@ def test_format_src_latex_minted_indented():
 
 
 def test_format_src_latex_minted_pycon():
-    before = (
-        "Preceding text\n"
-        "\\begin{minted}[gobble=2,showspaces]{pycon}\n"
-        ">>> print( 'Hello World' )\n"
-        "Hello World\n"
-        "\\end{minted}\n"
-        "Following text."
+    before = dedent(
+        """\
+        Preceding text
+        \\begin{minted}[gobble=2,showspaces]{pycon}
+        >>> print( 'Hello World' )
+        Hello World
+        \\end{minted}
+        Following text.
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "Preceding text\n"
-        "\\begin{minted}[gobble=2,showspaces]{pycon}\n"
-        '>>> print("Hello World")\n'
-        "Hello World\n"
-        "\\end{minted}\n"
-        "Following text."
+    assert after == dedent(
+        """\
+        Preceding text
+        \\begin{minted}[gobble=2,showspaces]{pycon}
+        >>> print("Hello World")
+        Hello World
+        \\end{minted}
+        Following text.
+        """
     )
 
 
 def test_format_src_latex_minted_pycon_indented():
     # Nicer style to put the \begin and \end on new lines,
     # but not actually required for the begin line
-    before = (
-        "Preceding text\n"
-        "  \\begin{minted}{pycon}\n"
-        "    >>> print( 'Hello World' )\n"
-        "    Hello World\n"
-        "  \\end{minted}\n"
-        "Following text."
+    before = dedent(
+        """\
+        Preceding text
+          \\begin{minted}{pycon}
+            >>> print( 'Hello World' )
+            Hello World
+          \\end{minted}
+        Following text.
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "Preceding text\n"
-        "  \\begin{minted}{pycon}\n"
-        '  >>> print("Hello World")\n'
-        "  Hello World\n"
-        "  \\end{minted}\n"
-        "Following text."
+    assert after == dedent(
+        """\
+        Preceding text
+          \\begin{minted}{pycon}
+          >>> print("Hello World")
+          Hello World
+          \\end{minted}
+        Following text.
+        """
     )
 
 
 def test_format_src_latex_minted_comments_off():
-    before = (
-        "% blacken-docs:off\n"
-        "\\begin{minted}{python}\n"
-        "'single quotes rock'\n"
-        "\\end{minted}\n"
-        "% blacken-docs:on\n"
+    before = dedent(
+        """\
+        % blacken-docs:off
+        \\begin{minted}{python}
+        'single quotes rock'
+        \\end{minted}
+        % blacken-docs:on
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_latex_minted_comments_off_pycon():
-    before = (
-        "% blacken-docs:off\n"
-        "\\begin{minted}{pycon}\n"
-        ">>> 'single quotes rock'\n"
-        "\\end{minted}\n"
-        "% blacken-docs:on\n"
+    before = dedent(
+        """\
+        % blacken-docs:off
+        \\begin{minted}{pycon}
+        >>> 'single quotes rock'
+        \\end{minted}
+        % blacken-docs:on
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
@@ -494,43 +567,65 @@ def test_format_src_latex_minted_comments_off_pycon():
 
 def test_format_src_pythontex():
     # fmt: off
-    before = (
-        "hello\n"
-        "\\begin{pyblock}\n"
-        "f(1,2,3)\n"
-        "\\end{pyblock}\n"
-        "world!"
+    before = dedent(
+        """\
+        hello
+        \\begin{pyblock}
+        f(1,2,3)
+        \\end{pyblock}
+        world!
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n"
-        "\\begin{pyblock}\n"
-        "f(1, 2, 3)\n"
-        "\\end{pyblock}\n"
-        "world!"
+    assert after == dedent(
+        """\
+        hello
+        \\begin{pyblock}
+        f(1, 2, 3)
+        \\end{pyblock}
+        world!
+        """
     )
     # fmt: on
 
 
 def test_format_src_pythontex_comments_off():
-    before = (
-        "% blacken-docs:off\n"
-        "\\begin{pyblock}\n"
-        "f(1,2,3)\n"
-        "\\end{pyblock}\n"
-        "% blacken-docs:on\n"
+    before = dedent(
+        """\
+        % blacken-docs:off
+        \\begin{pyblock}
+        f(1,2,3)
+        \\end{pyblock}
+        % blacken-docs:on
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_rst():
-    before = (
-        "hello\n" "\n" ".. code-block:: python\n" "\n" "    f(1,2,3)\n" "\n" "world\n"
+    before = dedent(
+        """\
+        hello
+
+        .. code-block:: python
+
+            f(1,2,3)
+
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n" "\n" ".. code-block:: python\n" "\n" "    f(1, 2, 3)\n" "\n" "world\n"
+    assert after == dedent(
+        """\
+        hello
+
+        .. code-block:: python
+
+            f(1, 2, 3)
+
+        world
+        """
     )
 
 
@@ -620,60 +715,66 @@ def test_format_src_rst_literal_blocks_empty():
 
 
 def test_format_src_rst_literal_blocks_comments():
-    before = (
-        ".. blacken-docs:off\n"
-        "Example::\n"
-        "\n"
-        "    'single quotes rock'\n"
-        "\n"
-        ".. blacken-docs:on\n"
+    before = dedent(
+        """\
+        .. blacken-docs:off
+        Example::
+
+            'single quotes rock'
+
+        .. blacken-docs:on
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE, rst_literal_blocks=True)
     assert after == before
 
 
 def test_format_src_rst_sphinx_doctest():
-    before = (
-        ".. testsetup:: group1\n"
-        "\n"
-        "   import parrot  \n"
-        "   mock = SomeMock( )\n"
-        "\n"
-        ".. testcleanup:: group1\n"
-        "\n"
-        "   mock.stop( )\n"
-        "\n"
-        ".. doctest:: group1\n"
-        "\n"
-        "   >>> parrot.voom( 3000 )\n"
-        "   This parrot wouldn't voom if you put 3000 volts through it!\n"
-        "\n"
-        ".. testcode::\n"
-        "\n"
-        "   parrot.voom( 3000 )\n"
-        "\n"
+    before = dedent(
+        """\
+        .. testsetup:: group1
+
+           import parrot
+           mock = SomeMock( )
+
+        .. testcleanup:: group1
+
+           mock.stop( )
+
+        .. doctest:: group1
+
+           >>> parrot.voom( 3000 )
+           This parrot wouldn't voom if you put 3000 volts through it!
+
+        .. testcode::
+
+           parrot.voom( 3000 )
+
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. testsetup:: group1\n"
-        "\n"
-        "   import parrot\n"
-        "\n"
-        "   mock = SomeMock()\n"
-        "\n"
-        ".. testcleanup:: group1\n"
-        "\n"
-        "   mock.stop()\n"
-        "\n"
-        ".. doctest:: group1\n"
-        "\n"
-        "   >>> parrot.voom(3000)\n"
-        "   This parrot wouldn't voom if you put 3000 volts through it!\n"
-        "\n"
-        ".. testcode::\n"
-        "\n"
-        "   parrot.voom(3000)\n"
-        "\n"
+    assert after == dedent(
+        """\
+        .. testsetup:: group1
+
+           import parrot
+
+           mock = SomeMock()
+
+        .. testcleanup:: group1
+
+           mock.stop()
+
+        .. doctest:: group1
+
+           >>> parrot.voom(3000)
+           This parrot wouldn't voom if you put 3000 volts through it!
+
+        .. testcode::
+
+           parrot.voom(3000)
+
+        """
     )
 
 
@@ -728,48 +829,56 @@ def test_format_src_rst_code_block_indent():
 
 
 def test_format_src_rst_with_highlight_directives():
-    before = (
-        ".. code-block:: python\n"
-        "    :lineno-start: 10\n"
-        "    :emphasize-lines: 11\n"
-        "\n"
-        "    def foo():\n"
-        "        bar(1,2,3)\n"
+    before = dedent(
+        """\
+        .. code-block:: python
+            :lineno-start: 10
+            :emphasize-lines: 11
+
+            def foo():
+                bar(1,2,3)
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: python\n"
-        "    :lineno-start: 10\n"
-        "    :emphasize-lines: 11\n"
-        "\n"
-        "    def foo():\n"
-        "        bar(1, 2, 3)\n"
+    assert after == dedent(
+        """\
+        .. code-block:: python
+            :lineno-start: 10
+            :emphasize-lines: 11
+
+            def foo():
+                bar(1, 2, 3)
+        """
     )
 
 
 def test_format_src_rst_python_inside_non_python_code_block():
-    before = (
-        "blacken-docs does changes like:\n"
-        "\n"
-        ".. code-block:: diff\n"
-        "\n"
-        "     .. code-block:: python\n"
-        "\n"
-        "    -    'Hello World'\n"
-        '    +    "Hello World"\n'
+    before = dedent(
+        """\
+        blacken-docs does changes like:
+
+        .. code-block:: diff
+
+             .. code-block:: python
+
+            -    'Hello World'
+            +    "Hello World"
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_rst_python_comments():
-    before = (
-        ".. blacken-docs:off\n"
-        ".. code-block:: python\n"
-        "\n"
-        "    'single quotes rock'\n"
-        "\n"
-        ".. blacken-docs:on\n"
+    before = dedent(
+        """\
+        .. blacken-docs:off
+        .. code-block:: python
+
+            'single quotes rock'
+
+        .. blacken-docs:on
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
@@ -1020,36 +1129,56 @@ def test_integration_ignored_syntax_error(tmp_path, capsys):
 
 
 def test_format_src_rst_jupyter_sphinx():
-    before = (
-        "hello\n" "\n" ".. jupyter-execute::\n" "\n" "    f(1,2,3)\n" "\n" "world\n"
+    before = dedent(
+        """\
+        hello
+
+        .. jupyter-execute::
+
+            f(1,2,3)
+
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n" "\n" ".. jupyter-execute::\n" "\n" "    f(1, 2, 3)\n" "\n" "world\n"
+    assert after == dedent(
+        """\
+        hello
+
+        .. jupyter-execute::
+
+            f(1, 2, 3)
+
+        world
+        """
     )
 
 
 def test_format_src_rst_jupyter_sphinx_with_directive():
-    before = (
-        "hello\n"
-        "\n"
-        ".. jupyter-execute::\n"
-        "    :hide-code:\n"
-        "\n"
-        "    f(1,2,3)\n"
-        "\n"
-        "world\n"
+    before = dedent(
+        """\
+        hello
+
+        .. jupyter-execute::
+            :hide-code:
+
+            f(1,2,3)
+
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n"
-        "\n"
-        ".. jupyter-execute::\n"
-        "    :hide-code:\n"
-        "\n"
-        "    f(1, 2, 3)\n"
-        "\n"
-        "world\n"
+    assert after == dedent(
+        """\
+        hello
+
+        .. jupyter-execute::
+            :hide-code:
+
+            f(1, 2, 3)
+
+        world
+        """
     )
 
 
@@ -1114,220 +1243,258 @@ def test_format_src_python_docstring_rst():
 
 
 def test_format_src_rst_pycon():
-    before = (
-        "hello\n"
-        "\n"
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> f(1,2,3)\n"
-        "    output\n"
-        "\n"
-        "world\n"
+    before = dedent(
+        """\
+        hello
+
+        .. code-block:: pycon
+
+            >>> f(1,2,3)
+            output
+
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        "hello\n"
-        "\n"
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> f(1, 2, 3)\n"
-        "    output\n"
-        "\n"
-        "world\n"
+    assert after == dedent(
+        """\
+        hello
+
+        .. code-block:: pycon
+
+            >>> f(1, 2, 3)
+            output
+
+        world
+        """
     )
 
 
 def test_format_src_rst_pycon_with_continuation():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> d = {\n"
-        '    ...   "a": 1,\n'
-        '    ...   "b": 2,\n'
-        '    ...   "c": 3,}\n'
-        "\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> d = {
+            ...   "a": 1,
+            ...   "b": 2,
+            ...   "c": 3,}
+
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> d = {\n"
-        '    ...     "a": 1,\n'
-        '    ...     "b": 2,\n'
-        '    ...     "c": 3,\n'
-        "    ... }\n"
-        "\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> d = {
+            ...     "a": 1,
+            ...     "b": 2,
+            ...     "c": 3,
+            ... }
+
+        """
     )
 
 
 def test_format_src_rst_pycon_adds_continuation():
     before = ".. code-block:: pycon\n" "\n" '    >>> d = {"a": 1,"b": 2,"c": 3,}\n' "\n"
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> d = {\n"
-        '    ...     "a": 1,\n'
-        '    ...     "b": 2,\n'
-        '    ...     "c": 3,\n'
-        "    ... }\n"
-        "\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> d = {
+            ...     "a": 1,
+            ...     "b": 2,
+            ...     "c": 3,
+            ... }
+
+        """
     )
 
 
 def test_format_src_rst_pycon_preserves_trailing_whitespace():
-    before = (
-        "hello\n"
-        "\n"
-        ".. code-block:: pycon\n"
-        "\n"
-        '    >>> d = {"a": 1, "b": 2, "c": 3}\n'
-        "\n"
-        "\n"
-        "\n"
-        "world\n"
+    before = dedent(
+        """\
+        hello
+
+        .. code-block:: pycon
+
+            >>> d = {"a": 1, "b": 2, "c": 3}
+
+
+
+        world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_rst_pycon_indented():
-    before = (
-        ".. versionadded:: 3.1\n"
-        "\n"
-        "    hello\n"
-        "\n"
-        "    .. code-block:: pycon\n"
-        "\n"
-        "        >>> def hi():\n"
-        "        ...     f(1,2,3)\n"
-        "        ...\n"
-        "\n"
-        "    world\n"
+    before = dedent(
+        """\
+        .. versionadded:: 3.1
+
+            hello
+
+            .. code-block:: pycon
+
+                >>> def hi():
+                ...     f(1,2,3)
+                ...
+
+            world
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. versionadded:: 3.1\n"
-        "\n"
-        "    hello\n"
-        "\n"
-        "    .. code-block:: pycon\n"
-        "\n"
-        "        >>> def hi():\n"
-        "        ...     f(1, 2, 3)\n"
-        "        ...\n"
-        "\n"
-        "    world\n"
+    assert after == dedent(
+        """\
+        .. versionadded:: 3.1
+
+            hello
+
+            .. code-block:: pycon
+
+                >>> def hi():
+                ...     f(1, 2, 3)
+                ...
+
+            world
+        """
     )
 
 
 def test_format_src_rst_pycon_code_block_is_final_line1():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...   pass\n"
-        "    ...\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...   pass
+            ...
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...     pass\n"
-        "    ...\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...     pass
+            ...
+        """
     )
 
 
 def test_format_src_rst_pycon_code_block_is_final_line2():
     before = ".. code-block:: pycon\n" "\n" "    >>> if True:\n" "    ...   pass\n"
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...     pass\n"
-        "    ...\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...     pass
+            ...
+        """
     )
 
 
 def test_format_src_rst_pycon_nested_def1():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...     def f(): pass\n"
-        "    ...\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...     def f(): pass
+            ...
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...     def f():\n"
-        "    ...         pass\n"
-        "    ...\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...     def f():
+            ...         pass
+            ...
+        """
     )
 
 
 def test_format_src_rst_pycon_nested_def2():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...     def f(): pass\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...     def f(): pass
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> if True:\n"
-        "    ...     def f():\n"
-        "    ...         pass\n"
-        "    ...\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> if True:
+            ...     def f():
+            ...         pass
+            ...
+        """
     )
 
 
 def test_format_src_rst_pycon_empty_line():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> l = [\n"
-        "    ...\n"
-        "    ...     1,\n"
-        "    ... ]\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> l = [
+            ...
+            ...     1,
+            ... ]
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> l = [\n"
-        "    ...     1,\n"
-        "    ... ]\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> l = [
+            ...     1,
+            ... ]
+        """
     )
 
 
 def test_format_src_rst_pycon_preserves_output_indentation():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> 1 / 0\n"
-        "    Traceback (most recent call last):\n"
-        '      File "<stdin>", line 1, in <module>\n'
-        "    ZeroDivisionError: division by zero\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> 1 / 0
+            Traceback (most recent call last):
+              File "<stdin>", line 1, in <module>
+            ZeroDivisionError: division by zero
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
 
 
 def test_format_src_rst_pycon_elided_traceback():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> 1 / 0\n"
-        "    Traceback (most recent call last):\n"
-        "      ...\n"
-        "    ZeroDivisionError: division by zero\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            >>> 1 / 0
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: division by zero
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before
@@ -1346,29 +1513,35 @@ def test_format_src_rst_pycon_no_trailing_newline():
 
 
 def test_format_src_rst_pycon_comment_before_promopt():
-    before = (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    # Comment about next line\n"
-        "    >>> pass\n"
+    before = dedent(
+        """\
+        .. code-block:: pycon
+
+            # Comment about next line
+            >>> pass
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
-    assert after == (
-        ".. code-block:: pycon\n"
-        "\n"
-        "    # Comment about next line\n"
-        "    >>> pass\n"
+    assert after == dedent(
+        """\
+        .. code-block:: pycon
+
+            # Comment about next line
+            >>> pass
+        """
     )
 
 
 def test_format_src_rst_pycon_comments():
-    before = (
-        ".. blacken-docs:off\n"
-        ".. code-block:: pycon\n"
-        "\n"
-        "    >>> 'single quotes rock'\n"
-        "\n"
-        ".. blacken-docs:on\n"
+    before = dedent(
+        """\
+        .. blacken-docs:off
+        .. code-block:: pycon
+
+            >>> 'single quotes rock'
+
+        .. blacken-docs:on
+        """
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == before


### PR DESCRIPTION
I wrote this script to do so:

```python
import ast
from textwrap import dedent
from pathlib import Path
import re
from posix import remove


def main(argv):
    for name in argv:
        path = Path(name)
        text = path.read_text()

        def replace(match):
            node = ast.parse(dedent(match[0]))
            if match[1] == "before =":
                string = node.body[0].value.value
            else:
                string = node.body[0].test.comparators[0].value
            lines = [
                f"    {match[1]} dedent(",
                '        """\\',
            ]
            for line in string.splitlines():
                stripped = repr(line)[1:-1].rstrip()
                if stripped:
                    lines.append(f"        {stripped}")
                else:
                    lines.append("")
            lines.append('        """')
            lines.append("    )")
            return "\n".join(lines)

        text = re.sub(
            r"    (before =|assert after ==) \(\n.*?    \)",
            replace,
            text,
            flags=re.DOTALL,
        )

        path.write_text(text)


if __name__ == "__main__":
    import sys

    main(sys.argv[1:])
```

Run with:

`python convert.py tests/test_blacken_docs.py`